### PR TITLE
Fixed private fuzzable functions.

### DIFF
--- a/sbomfuzz/.vscode/tasks.json
+++ b/sbomfuzz/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "build webview",
             "type": "shell",
-            "command": "npm run compile && npm run build:webview",
+            "command": "npm run compile_build",
             "problemMatcher": [],
             "group": {
                 "kind": "build",

--- a/sbomfuzz/package.json
+++ b/sbomfuzz/package.json
@@ -59,7 +59,8 @@
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
     "test": "vscode-test",
-    "build:webview": "vite build"
+    "build:webview": "vite build",
+    "compile_build": "npm run compile && npm run build:webview"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/sbomfuzz/src/extension.ts
+++ b/sbomfuzz/src/extension.ts
@@ -2,7 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
 import { SbomFuzzWebviewViewProvider } from "./view";
-import { RustFunctionCodeLensProvider } from "./rustFunctionCodeLensProvider";
+import { make_function_public, RustFunctionCodeLensProvider } from "./rustFunctionCodeLensProvider";
 import { findFuzzRoot } from "./util";
 import { useGlobalContext } from "./globalContextProvider";
 import path from "path";
@@ -48,6 +48,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "sbomfuzz.showFunctionInfo", // same as used in CodeLens
       (functionName: string, filePath: string) => {
+        // Make sure function is public
+        make_function_public(filePath, functionName);
+
         // ? we get the webview from the provider, the webview is static
         const webview = SbomFuzzWebviewViewProvider.getWebview();
         if (webview) {
@@ -68,3 +71,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 // This method is called when your extension is deactivated
 export function deactivate() {}
+
+
+
+
+
+
+


### PR DESCRIPTION
The "sbomfuzz.showFunctionInfo" vscode extension command for creating a fuzz harness now makes a function public if it was not already public. This is required for the fuzz harness in the fuzz directory to find it.